### PR TITLE
Fixed size for each card in the 2d classification

### DIFF
--- a/src/legacy/pages/em/classification/classificationpanel.tsx
+++ b/src/legacy/pages/em/classification/classificationpanel.tsx
@@ -13,10 +13,6 @@ export default function ClassificationPanel({
   classification,
   proposalName,
 }: Props) {
-  if (!classification) {
-    return <></>;
-  }
-
   const {
     particleClassificationId,
     classDistribution,

--- a/src/legacy/pages/em/classification/classificationpanel.tsx
+++ b/src/legacy/pages/em/classification/classificationpanel.tsx
@@ -19,7 +19,6 @@ export default function ClassificationPanel({
     estimatedResolution,
     classNumber,
   } = classification;
-
   return (
     <Card>
       <Card.Header># Class {classNumber}</Card.Header>

--- a/src/legacy/pages/em/classification/classificationpanel.tsx
+++ b/src/legacy/pages/em/classification/classificationpanel.tsx
@@ -13,12 +13,17 @@ export default function ClassificationPanel({
   classification,
   proposalName,
 }: Props) {
+  if (!classification) {
+    return <></>;
+  }
+
   const {
     particleClassificationId,
     classDistribution,
     estimatedResolution,
     classNumber,
   } = classification;
+
   return (
     <Card>
       <Card.Header># Class {classNumber}</Card.Header>

--- a/src/legacy/pages/em/classification/sessionclassificationpage.tsx
+++ b/src/legacy/pages/em/classification/sessionclassificationpage.tsx
@@ -85,6 +85,8 @@ export default function SessionClassificationPage() {
                         .sort((a: Classification, b: Classification) => {
                           return b.classDistribution - a.classDistribution;
                         })
+
+                        .concat([...Array(10)]) // Trick to make the elements of the card panel have got same size
                         .map((c, i) => (
                           <Col key={i} style={{ margin: 2 }}>
                             <ClassificationPanel

--- a/src/legacy/pages/em/classification/sessionclassificationpage.tsx
+++ b/src/legacy/pages/em/classification/sessionclassificationpage.tsx
@@ -86,15 +86,7 @@ export default function SessionClassificationPage() {
                           return b.classDistribution - a.classDistribution;
                         })
                         .map((c, i) => (
-                          <Col
-                            key={i}
-                            style={{ margin: 2 }}
-                            xs={12}
-                            sm={6}
-                            lg={4}
-                            xl={3}
-                            xxl={2}
-                          >
+                          <Col key={i} xs={12} sm={6} lg={4} xl={3} xxl={2}>
                             <ClassificationPanel
                               classification={c}
                               proposalName={proposalName}

--- a/src/legacy/pages/em/classification/sessionclassificationpage.tsx
+++ b/src/legacy/pages/em/classification/sessionclassificationpage.tsx
@@ -85,10 +85,16 @@ export default function SessionClassificationPage() {
                         .sort((a: Classification, b: Classification) => {
                           return b.classDistribution - a.classDistribution;
                         })
-
-                        .concat([...Array(10)]) // Trick to make the elements of the card panel have got same size
                         .map((c, i) => (
-                          <Col key={i} style={{ margin: 2 }}>
+                          <Col
+                            key={i}
+                            style={{ margin: 2 }}
+                            xs={12}
+                            sm={6}
+                            lg={4}
+                            xl={3}
+                            xxl={2}
+                          >
                             <ClassificationPanel
                               classification={c}
                               proposalName={proposalName}


### PR DESCRIPTION
It keeps the same size for each card:
![image](https://user-images.githubusercontent.com/2901169/221581337-8b82e8e6-4464-4179-9209-6b127a9b6322.png)


Previous version was:
![image](https://user-images.githubusercontent.com/2901169/221581426-0c685139-0bdc-499f-bb93-868c7bef621b.png)
